### PR TITLE
Update view.py according to garden.mapview #41

### DIFF
--- a/mapview/view.py
+++ b/mapview/view.py
@@ -286,6 +286,7 @@ class MapView(Widget):
     _zoom = NumericProperty(0)
     _pause = BooleanProperty(False)
     _scale = 1.
+    _disabled_count = 0
 
     __events__ = ["on_map_relocated"]
 


### PR DESCRIPTION
https://github.com/kivy-garden/garden.mapview/commit/f6a29749244775a8f9a7dfef09505a381cac36b8

This fixes the widget._disabled_count = self._disabled_count AttributeError: 'MapView' object has no attribute '_disabled_count' error.